### PR TITLE
fixing typo causing a bug with setTime

### DIFF
--- a/nexstar/__init__.py
+++ b/nexstar/__init__.py
@@ -368,7 +368,7 @@ class NexstarHandController:
         if zone < 0:
             zone += 256
 
-        request = [NexStarCommand.SET_TIME, hour, minute, second, month, day, year, zone, dst]
+        request = [NexstarCommand.SET_TIME, hour, minute, second, month, day, year, zone, dst]
         self._write(request)
 
         # Response is a single hash ('#') character. Drop it.


### PR DESCRIPTION
Hi there!

I'm attempting to use this library to set the time on my telescope, and it's throwing an error due to a typo in the class name.  I'm submitting a PR to fix the issue. 

Cheers,
Matt


----------------------------------------
Exception happened during processing of request from ('xxxxxxxxx', 51388)
Traceback (most recent call last):
  File "/usr/lib/python3.7/socketserver.py", line 650, in process_request_thread
    self.finish_request(request, client_address)
  File "/usr/lib/python3.7/socketserver.py", line 360, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/lib/python3.7/socketserver.py", line 720, in __init__
    self.handle()
  File "/usr/lib/python3.7/http/server.py", line 426, in handle
    self.handle_one_request()
  File "/usr/lib/python3.7/http/server.py", line 414, in handle_one_request
    method()
  File "serveHttp.py", line 77, in do_GET
    handControl.setTime(timestamp, 0)
  File "/home/pi/.local/lib/python3.7/site-packages/nexstar/__init__.py", line 371, in setTime
    request = [NexStarCommand.SET_TIME, hour, minute, second, month, day, year, zone, dst]
NameError: name 'NexStarCommand' is not defined
----------------------------------------



