### PR TITLE
Timezone bug

### DIFF
--- a/nexstar/__init__.py
+++ b/nexstar/__init__.py
@@ -190,14 +190,12 @@ class NexstarHandController:
         # Initiate a "GoTo" command.
 
         if highPrecisionFlag:
-            #command = NexstarCommand.GOTO_POSITION_AZM_ALT_PRECISE if (coordinateMode == NexstarCoordinateMode.AZM_ALT) else NexstarCommand.GOTO_POSITION_RA_DEC_PRECISE
-            command = NexstarCommand.GOTO_POSITION_RA_DEC_PRECISE
+            command = NexstarCommand.GOTO_POSITION_AZM_ALT_PRECISE if (coordinateMode == NexstarCoordinateMode.AZM_ALT) else NexstarCommand.GOTO_POSITION_RA_DEC_PRECISE
             firstCoordinate  = round(float(firstCoordinate)  / 360.0 * 0x100000000)
             secondCoordinate = round(float(secondCoordinate) / 360.0 * 0x100000000)
             coordinates = "{:08x},{:08x}".format(firstCoordinate, secondCoordinate)
         else:
-            #command = NexstarCommand.GOTO_POSITION_AZM_ALT if (coordinateMode == NexstarCoordinateMode.AZM_ALT) else NexstarCommand.GOTO_POSITION_RA_DEC
-            command = NexstarCommand.GOTO_POSITION_RA_DEC
+            command = NexstarCommand.GOTO_POSITION_AZM_ALT if (coordinateMode == NexstarCoordinateMode.AZM_ALT) else NexstarCommand.GOTO_POSITION_RA_DEC
             firstCoordinate  = round(float(firstCoordinate)  / 360.0 * 0x10000)
             secondCoordinate = round(float(secondCoordinate) / 360.0 * 0x10000)
             print(firstCoordinate, secondCoordinate)
@@ -218,12 +216,12 @@ class NexstarHandController:
             command = NexstarCommand.SYNC_PRECISE
             firstCoordinate  = round(float(firstCoordinate)  / 360.0 * 0x100000000)
             secondCoordinate = round(float(secondCoordinate) / 360.0 * 0x100000000)
-            coordinates = "{}{:08x},{:08x}".format(firstCoordinate, secondCoordinate)
+            coordinates = "{:08x},{:08x}".format(firstCoordinate, secondCoordinate)
         else:
             command = NexstarCommand.SYNC
             firstCoordinate  = round(float(firstCoordinate)  / 360.0 * 0x10000)
             secondCoordinate = round(float(secondCoordinate) / 360.0 * 0x10000)
-            coordinates = "{}{:04x},{:04x}".format(firstCoordinate, secondCoordinate)
+            coordinates = "{:04x},{:04x}".format(firstCoordinate, secondCoordinate)
 
         self._write(command, coordinates)
 
@@ -371,7 +369,6 @@ class NexstarHandController:
         day    = timestamp.day
         year   = timestamp.year - 2000
 
-        #zone = round(timestamp.utcoffset() / datetime.timedelta(hours = 1))
         zone = tzone
         if zone < 0:
             zone += 256

--- a/nexstar/__init__.py
+++ b/nexstar/__init__.py
@@ -190,14 +190,17 @@ class NexstarHandController:
         # Initiate a "GoTo" command.
 
         if highPrecisionFlag:
-            command = NexstarCommand.GOTO_POSITION_AZM_ALT_PRECISE if (coordinateMode == NexstarCoordinateMode.AZM_ALT) else NexstarCommand.GOTO_POSITION_RA_DEC_PRECISE
+            #command = NexstarCommand.GOTO_POSITION_AZM_ALT_PRECISE if (coordinateMode == NexstarCoordinateMode.AZM_ALT) else NexstarCommand.GOTO_POSITION_RA_DEC_PRECISE
+            command = NexstarCommand.GOTO_POSITION_RA_DEC_PRECISE
             firstCoordinate  = round(float(firstCoordinate)  / 360.0 * 0x100000000)
             secondCoordinate = round(float(secondCoordinate) / 360.0 * 0x100000000)
             coordinates = "{:08x},{:08x}".format(firstCoordinate, secondCoordinate)
         else:
-            command = NexstarCommand.GOTO_POSITION_AZM_ALT if (coordinateMode == NexstarCoordinateMode.AZM_ALT) else NexstarCommand.GOTO_POSITION_RA_DEC
+            #command = NexstarCommand.GOTO_POSITION_AZM_ALT if (coordinateMode == NexstarCoordinateMode.AZM_ALT) else NexstarCommand.GOTO_POSITION_RA_DEC
+            command = NexstarCommand.GOTO_POSITION_RA_DEC
             firstCoordinate  = round(float(firstCoordinate)  / 360.0 * 0x10000)
             secondCoordinate = round(float(secondCoordinate) / 360.0 * 0x10000)
+            print(firstCoordinate, secondCoordinate)
             coordinates = "{:04x},{:04x}".format(firstCoordinate, secondCoordinate)
 
         self._write(command, coordinates)
@@ -359,7 +362,7 @@ class NexstarHandController:
 
         return (timestamp, dst)
 
-    def setTime(self, timestamp, dst):
+    def setTime(self, timestamp, tzone, dst):
 
         hour   = timestamp.hour
         minute = timestamp.minute
@@ -368,7 +371,8 @@ class NexstarHandController:
         day    = timestamp.day
         year   = timestamp.year - 2000
 
-        zone = round(timestamp.utcoffset() / datetime.timedelta(hours = 1))
+        #zone = round(timestamp.utcoffset() / datetime.timedelta(hours = 1))
+        zone = tzone
         if zone < 0:
             zone += 256
 
@@ -638,7 +642,7 @@ def main():
     if False:
 
         timestamp = datetime.datetime.now(tz)
-        controller.setTime(timestamp, 0)
+        controller.setTime(timestamp,0,0)
 
         #(timestamp, dst) = controller.getTime()
         #timestamp = timestamp.astimezone(tz)


### PR DESCRIPTION
Hi, thank you for providing this code it has been extremely useful for my astronomy project. In mid september 2021 I tested this code on sky in the UTC+0 timezone. I noticed that the telescope pointing was off by an hour in RA when trying to slew to targets by their RA/DEC. I determined that this was because your pytz timezone code using 'Europe/London' (UTC+0) gave me GMT+1 or BST since I was querying the timezone during daylight savings. Unfortunately, as daylight savings is also specified to the mount it seems that it added another hour on automatically and thought I was in UTC+1 as a result. I have fixed this by implementing the Nexstar command specification to use the +/-0,1,2,3 etc as the timezone input instead of a pytz object. It should also be possible to do it automatically by removing the +1 hour from daylight savings.

Also there was an extra set of {} in the sync command which was throwing errors.